### PR TITLE
Add an asterisk to ID column for zometool constructible models.

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,10 +8,10 @@
   <meta name="twitter:card" content="summary_large_image"/>
   <meta property="og:type" content="website"/>
 
-  <title>Johnson Solids with vZome</title>
-  <meta property="og:site_name"  content="Johnson Solids with vZome"/>
-  <meta property="og:title"      content="Johnson Solids with vZome"/>
-  <meta property="twitter:title" content="Johnson Solids with vZome"/>
+  <title>Johnson Solids</title>
+  <meta property="og:site_name"  content="Johnson Solids"/>
+  <meta property="og:title"      content="Johnson Solids"/>
+  <meta property="twitter:title" content="Johnson Solids"/>
 
   <meta name="description"             content="vZome 3D models of the Johnson solids"/>
   <meta property="og:description"      content="vZome 3D models of the Johnson solids"/>
@@ -37,12 +37,12 @@
   <div class="main-grid">
     <div class="intro">
       <h1>
-        Johnson Solids with <a href="https://vzome.com" target="_blank" rel="noopener">vZome</a>
+        Johnson Solids made with <a href="https://vzome.com" target="_blank" rel="noopener">vZome</a>
       </h1>    
       <p>
         Select a row in the table to view that Johnson solid.<br>
         Check the box in the viewer to show struts and balls for 
-        <a href="https://www.zometool.com" target="_blank" rel="noopener">Zometool</a> constructible solids.
+        <a href="https://www.zometool.com" target="_blank" rel="noopener">Zometool</a> constructible solids marked by an asterisk.
       </p>
       <p>
         Use your mouse to manipulate the 3D view: left button to rotate, right button to pan, and scroll gesture to zoom.

--- a/johnson-solids-listing.js
+++ b/johnson-solids-listing.js
@@ -57,7 +57,8 @@ function fillRow(tr, jsolid) {
   // Id column
   let td = tr.insertCell();
   td.className = url ? "ident done" : "ident todo";
-  td.innerHTML = "J" + id;
+  const zomeBuildable = field == "Golden" && zometool == "true" && url ? "*" : "";
+  td.innerHTML = zomeBuildable + "J" + id;
   // title column
   td = tr.insertCell();
   td.className = "title";

--- a/style.css
+++ b/style.css
@@ -119,7 +119,7 @@ table {
 thead th:nth-child(1)   /* id column */
 {
   text-align: center;
-  width: 6%;
+  width: 4ch;
 }
 tbody td:nth-child(1)   /* id column */
 {
@@ -137,6 +137,10 @@ td {
 th.ident, td.done {
   background-color: var(--color-ident);
   font-weight: bold;
+}
+
+th.ident, td.ident {
+  width: 45ch; /* J77 and J78 have 45 characters in their names. No others are longer. */
 }
 
 td.todo {
@@ -167,11 +171,13 @@ tr.selected > td:last-child.root3 {
 }
 
 td.polygon12, 
+td.polygon20, 
 td.polygon30, 
 td.polygon60 {
   background-color: var(--color-red-panel);
 }
 tr.selected > td:last-child.polygon12,
+tr.selected > td:last-child.polygon20,
 tr.selected > td:last-child.polygon30,
 tr.selected > td:last-child.polygon60 {
   background-color: var(--color-red-strut);


### PR DESCRIPTION
ID column is fixed at 4 characters wide instead of a percentage.
Cleaned up some metadata per comments from Scott.
