### PR TITLE
Restore one-time listener since the viewer race condition is not yet fixed

### DIFF
--- a/johnson-solids-listing.js
+++ b/johnson-solids-listing.js
@@ -277,8 +277,21 @@ function getFaceSceneSnapshots(modelData) {
 viewer .addEventListener( "vzome-scenes-discovered", (e) => {
   // Just logging this to the console for now. Not actually using the scenes list.
   const scenes = e.detail;
+  //console.log( "These scenes were discovered in " + viewer.src);
   console.log( JSON.stringify( scenes, null, 2 ) );
 } );
+
+// TODO: Remove this listener after the race condition is fixed
+viewer .addEventListener( "vzome-scenes-discovered", (e) => {
+  console.log( "This event handler is only triggered the first time a vzome scene is discovered after the page is loaded.\n"
+	+ "It is a work around for the intermittant race condition that results in the wrong camera zoom level.\n"
+	+ "The same race condition may still result in showing the wrong background color, but at least the camera zoom is consistent.\n"
+	+ "If the vzome-viewer revision is shown ABOVE this message, then the background color was read from .shapes.json.\n"
+	+ "If the vzome-viewer revision is shown BELOW this message, then the default background color of the viewer is being used.\n"
+	);
+  viewer.update({ camera: true }); // force a camera update, but background color may still be wrong.
+},
+{once: true}); // automatically remove this listener after it is fired once
 
 for (const jsolid of models) {
   const tr = tbody.insertRow();


### PR DESCRIPTION
This reverts commit 92ed69372a900bd3c8402859ee488f313c423b42.
